### PR TITLE
Added lib64 install paths for gettext on redhat

### DIFF
--- a/buildout-build-redhat-64bit.cfg
+++ b/buildout-build-redhat-64bit.cfg
@@ -40,3 +40,7 @@ patches = ${:patches-dir}/${:name}-${:version}-sysconfig.py.patch
 [bzip2]
 patches = ${:patches-dir}/${:name}-${:version}-unix-Makefile.patch
     ${:patches-dir}/${:name}-${:version}-redhat-lib64.patch
+
+[gettext]
+configure-options = --prefix=${options:prefix} --disable-rpath --without-git --without-cvs --libdir=${options:prefix}/lib64
+


### PR DESCRIPTION
Simple bug fix, self explanitory in the commit message
