### PR TITLE
Config changes needed to build on CentOS 6 with newer GCC

### DIFF
--- a/buildout-build-redhat-64bit-with-libvirt.cfg
+++ b/buildout-build-redhat-64bit-with-libvirt.cfg
@@ -7,7 +7,15 @@ parts = zlib ncurses readline openssl openssh libgpg-error libgcrypt gettext lib
    gnu
 recipe = hexagonit.recipe.cmmi
 version = 1.02.28
-configure-options = --prefix=${options:prefix} --disable-rpath --libdir=${options:prefix}/lib64 --disable-selinux
+configure-options = --prefix=${options:prefix} --disable-rpath --libdir=${options:prefix}/lib64 --disable-selinux --with-user=$USER --with-group=$GROUP
+url = ${urls:source}/${:name}-${:version}.tgz
+
+[libgpg-error]
+version = 1.22
+
+[libgcrypt]
+patches = ${:patches-dir}/${:name}-${:version}-mpi-mpi-internal.h.patch
+    ${:patches-dir}/${:name}-${:version}-mpi-mpi-inline.h.patch
 
 [libvirt]
 <= options
@@ -15,3 +23,7 @@ configure-options = --prefix=${options:prefix} --disable-rpath --libdir=${option
 recipe = hexagonit.recipe.cmmi
 version = 3.9.0
 configure-options = ${options:configure-options} --without-macvtap --without-yajl
+url = ${urls:source}/${:name}-${:version}.tgz
+
+[ncurses]
+patches = ${:patches-dir}/${:name}-${:version}-ncurses-base-MKlib_gen.sh.patch


### PR DESCRIPTION
These changes will probably need to be handled in a better way, but wanted
to start with what I have now to determine the proper fix moving forward.

Due to a newer-than-standard GCC being installed on our system (6.3.1),
some additional changes (mostly pulled from the Ubuntu 16.04 config) were
needed to get a full build.

The 'url' additions to device-mapper and libvirt were needed to allow
the tarballs to be extracted.

The '--with-user'/'--with-group' additions to device-mapper were needed
to build as non-root (otherwise installation of certain files failed as
it tried to chown them).

As it stands, not everyone should be building with a newer GCC on CentOS 6,
so probably finding a way to conditionalize on the version of GCC would be
a better solution, but I'm unsure of how to do this, being a bit new to buildout.
Suggestions greatly appreciated.